### PR TITLE
Alternative to wrap an AppUpgrader

### DIFF
--- a/AppUpgradable.playground/Contents.swift
+++ b/AppUpgradable.playground/Contents.swift
@@ -15,13 +15,25 @@ enum MyAppVersion: Int, AppVersion {
     case v2_1
     case v3_0
     case v4_0
+}
+
+class MyAppUpgrader: AppUpgradable {
+    private let upgrader: AppUpgrader<MyAppVersion>
     
-    var name: String {
-        return "com.company.myappversion"
+    init() {
+        self.upgrader = AppUpgrader<MyAppVersion>(name: "com.company.myappversion")
     }
     
-    func upgradeClosure() -> () -> UpgradeResult {
-        switch self {
+    func upgradeApp() throws {
+        try upgrader.upgrade(toVersion: upgrader.getCurrentVersion(), upgradeClosure: upgrade)
+    }
+    
+    func getCurrentVersion() -> AppVersion {
+        return upgrader.getCurrentVersion()
+    }
+    
+    private func upgrade(_ version: MyAppVersion) -> () -> UpgradeResult {
+        switch version {
         case .v0_0: return { .success } // this is here to satisfy the switch statement without putting in 'default'
         case .v1_0: return upgradeToVersion_1_0
         case .v1_1: return upgradeToVersion_1_1
@@ -32,14 +44,14 @@ enum MyAppVersion: Int, AppVersion {
         }
     }
     
-    func upgradeToVersion_1_0() -> UpgradeResult {
+    private func upgradeToVersion_1_0() -> UpgradeResult {
         print("doing stuff for 0.0 to 1.0 initial launch")
         print("- like setup user defaults")
         
         return .success
     }
     
-    func upgradeToVersion_1_1() -> UpgradeResult {
+    private func upgradeToVersion_1_1() -> UpgradeResult {
         print("doing stuff for 1.0 to 1.1 upgrade")
         print("- updating user settings")
         print("-- (non-fatal) couldn't retain the user's volume setting")
@@ -47,7 +59,7 @@ enum MyAppVersion: Int, AppVersion {
         return .nonFatalError(UserDefaultsError.lostVolumeSetting)
     }
     
-    func upgradeToVersion_2_0_original() -> UpgradeResult {
+    private func upgradeToVersion_2_0_original() -> UpgradeResult {
         var errors = [UpgradeResult]()
         print("doing stuff for 1.1 to 2.0 upgrade (original)")
         print("- converting files")
@@ -60,7 +72,7 @@ enum MyAppVersion: Int, AppVersion {
         return .errors(errors)
     }
     
-    func upgradeToVersion_2_0_new() -> UpgradeResult {
+    private func upgradeToVersion_2_0_new() -> UpgradeResult {
         print("doing stuff for 1.1 to 2.1 upgrade (avoiding the mistake in 2.0)")
         print("- pushing files to the cloud")
         print("-- correctly pushing files to the cloud")
@@ -68,28 +80,28 @@ enum MyAppVersion: Int, AppVersion {
         return UpgradeResult.success.jump(toVersion: MyAppVersion.v2_1)
     }
     
-    func upgradeToVersion_2_1() -> UpgradeResult {
+    private func upgradeToVersion_2_1() -> UpgradeResult {
         print("doing stuff for 2.0 to 2.1 upgrade")
         print("- fixing issue caused by 2.0 upgrade")
         
         return .success
     }
     
-    func upgradeToVersion_3_0_original() -> UpgradeResult {
+    private func upgradeToVersion_3_0_original() -> UpgradeResult {
         print("doing stuff for 2.1 to 3.0 upgrade (original)")
         print("- change to a new file structure")
         
         return .success
     }
     
-    func upgradeToVersion_3_0_new() -> UpgradeResult {
+    private func upgradeToVersion_3_0_new() -> UpgradeResult {
         print("doing stuff for 2.1 to 4.0 upgrade (avoid changing the file structure just to change it back)")
         print("- NOT changing to a new file structure")
         
         return UpgradeResult.success.jump(toVersion: MyAppVersion.v4_0)
     }
     
-    func upgradeToVersion_4_0() -> UpgradeResult {
+    private func upgradeToVersion_4_0() -> UpgradeResult {
         print("doing stuff for 3.0 to 4.0 upgrade")
         print("- 3.0 was a mistake, change file structure back to what it was")
         
@@ -97,7 +109,7 @@ enum MyAppVersion: Int, AppVersion {
     }
 }
 
-let myAppUpgrader = AppUpgrader<MyAppVersion>(version: .v1_0)
+let myAppUpgrader = MyAppUpgrader()
 
 do {
     try myAppUpgrader.upgradeApp()

--- a/AppUpgradable.playground/Contents.swift
+++ b/AppUpgradable.playground/Contents.swift
@@ -1,37 +1,27 @@
-
-// MARK: Example - Conforming to AppUpgradable
-
 enum UserDefaultsError: Error {
     case lostVolumeSetting
 }
+
 enum DataMigrationError: Error {
     case failedToRetainUserSettings
     case failedToUpdateiCloud
 }
 
-class AppUpgrader: AppUpgradable {
-    var currentVersion = Version.v0_0
+enum MyAppVersion: Int, AppVersion {
+    case v0_0
+    case v1_0
+    case v1_1
+    case v2_0
+    case v2_1
+    case v3_0
+    case v4_0
     
-    enum Version: Int {
-        case v0_0
-        case v1_0
-        case v1_1
-        case v2_0
-        case v2_1
-        case v3_0
-        case v4_0
+    var name: String {
+        return "com.company.myappversion"
     }
     
-    func getCurrentVersion() -> Version {
-        return currentVersion
-    }
-    func setCurrentVersion(version: Version) {
-        print("\n* setting the current version to \(version)\n")
-        currentVersion = version
-    }
-    
-    func upgradeClosure(toVersion version: Version) -> () -> UpgradeResult {
-        switch version {
+    func upgradeClosure() -> () -> UpgradeResult {
+        switch self {
         case .v0_0: return { .success } // this is here to satisfy the switch statement without putting in 'default'
         case .v1_0: return upgradeToVersion_1_0
         case .v1_1: return upgradeToVersion_1_1
@@ -69,15 +59,15 @@ class AppUpgrader: AppUpgradable {
         
         return .errors(errors)
     }
-
+    
     func upgradeToVersion_2_0_new() -> UpgradeResult {
         print("doing stuff for 1.1 to 2.1 upgrade (avoiding the mistake in 2.0)")
         print("- pushing files to the cloud")
         print("-- correctly pushing files to the cloud")
         
-        return UpgradeResult.success.jump(toVersion: Version.v2_1)
+        return UpgradeResult.success.jump(toVersion: MyAppVersion.v2_1)
     }
-
+    
     func upgradeToVersion_2_1() -> UpgradeResult {
         print("doing stuff for 2.0 to 2.1 upgrade")
         print("- fixing issue caused by 2.0 upgrade")
@@ -96,9 +86,9 @@ class AppUpgrader: AppUpgradable {
         print("doing stuff for 2.1 to 4.0 upgrade (avoid changing the file structure just to change it back)")
         print("- NOT changing to a new file structure")
         
-        return UpgradeResult.success.jump(toVersion: Version.v4_0)
+        return UpgradeResult.success.jump(toVersion: MyAppVersion.v4_0)
     }
-
+    
     func upgradeToVersion_4_0() -> UpgradeResult {
         print("doing stuff for 3.0 to 4.0 upgrade")
         print("- 3.0 was a mistake, change file structure back to what it was")
@@ -107,17 +97,14 @@ class AppUpgrader: AppUpgradable {
     }
 }
 
-// EXAMPLE - Upgrading the App
-
-let myAppUpgrader = AppUpgrader()
-myAppUpgrader.setCurrentVersion(version: .v0_0)
+let myAppUpgrader = AppUpgrader<MyAppVersion>(version: .v1_0)
 
 do {
     try myAppUpgrader.upgradeApp()
     print("Upgrade Completed Successfully")
     
 } catch UpgradeError.Canceled(let rawVersion, let fatalErrors, let nonFatalErrors) {
-    let version = AppUpgrader.Version(rawValue: rawVersion)!
+    let version = rawVersion
     print("\nUpgrade Failed:")
     print("- on version \(version)")
     print("- FATAL errors \(fatalErrors)")
@@ -125,6 +112,8 @@ do {
     
 } catch UpgradeError.CompletedWithErrors(let errors) {
     print("Upgrade Completed: with errors \(errors)")
+} catch {
+    print("Unknown error")
 }
 
 print("\nFinished Upgrade: new version \(myAppUpgrader.getCurrentVersion())")

--- a/AppUpgradable.playground/Contents.swift
+++ b/AppUpgradable.playground/Contents.swift
@@ -25,14 +25,14 @@ class MyAppUpgrader: AppUpgradable {
     }
     
     func upgradeApp() throws {
-        try upgrader.upgrade(toVersion: upgrader.getCurrentVersion(), upgradeClosure: upgrade)
+        try upgrader.upgrade(toVersion: upgrader.getCurrentVersion(), upgradeClosure: upgradeToVersion)
     }
     
     func getCurrentVersion() -> AppVersion {
         return upgrader.getCurrentVersion()
     }
     
-    private func upgrade(_ version: MyAppVersion) -> () -> UpgradeResult {
+    private func upgradeToVersion(_ version: MyAppVersion) -> () -> UpgradeResult {
         switch version {
         case .v0_0: return { .success } // this is here to satisfy the switch statement without putting in 'default'
         case .v1_0: return upgradeToVersion_1_0
@@ -43,6 +43,8 @@ class MyAppUpgrader: AppUpgradable {
         case .v4_0: return upgradeToVersion_4_0
         }
     }
+    
+    // MARK: - Upgrade Methods
     
     private func upgradeToVersion_1_0() -> UpgradeResult {
         print("doing stuff for 0.0 to 1.0 initial launch")

--- a/AppUpgradable.playground/Contents.swift
+++ b/AppUpgradable.playground/Contents.swift
@@ -32,6 +32,8 @@ class MyAppUpgrader: AppUpgradable {
         return upgrader.getCurrentVersion()
     }
     
+    // MARK: - Upgrade Methods
+    
     private func upgradeToVersion(_ version: MyAppVersion) -> () -> UpgradeResult {
         switch version {
         case .v0_0: return { .success } // this is here to satisfy the switch statement without putting in 'default'
@@ -43,9 +45,7 @@ class MyAppUpgrader: AppUpgradable {
         case .v4_0: return upgradeToVersion_4_0
         }
     }
-    
-    // MARK: - Upgrade Methods
-    
+
     private func upgradeToVersion_1_0() -> UpgradeResult {
         print("doing stuff for 0.0 to 1.0 initial launch")
         print("- like setup user defaults")

--- a/AppUpgradable.playground/Contents.swift
+++ b/AppUpgradable.playground/Contents.swift
@@ -18,31 +18,31 @@ enum MyAppVersion: Int, AppVersion {
 }
 
 class MyAppUpgrader: AppUpgradable {
-    private let upgrader: AppUpgrader<MyAppVersion>
+    private let appUpgrader: AppUpgrader<MyAppVersion>
     
-    init() {
-        self.upgrader = AppUpgrader<MyAppVersion>(name: "com.company.myappversion")
+    init(appUpgrader: AppUpgrader<MyAppVersion>) {
+        self.appUpgrader = appUpgrader
     }
     
     func upgradeApp() throws {
-        try upgrader.upgrade(toVersion: upgrader.getCurrentVersion(), upgradeClosure: upgradeToVersion)
+        try appUpgrader.upgrade(upgradeClosure: upgradeToVersion)
     }
     
     func getCurrentVersion() -> AppVersion {
-        return upgrader.getCurrentVersion()
+        return appUpgrader.getCurrentVersion()
     }
     
     // MARK: - Upgrade Methods
     
-    private func upgradeToVersion(_ version: MyAppVersion) -> () -> UpgradeResult {
+    private func upgradeToVersion(_ version: MyAppVersion) -> UpgradeResult {
         switch version {
-        case .v0_0: return { .success } // this is here to satisfy the switch statement without putting in 'default'
-        case .v1_0: return upgradeToVersion_1_0
-        case .v1_1: return upgradeToVersion_1_1
-        case .v2_0: return upgradeToVersion_2_0_new // (issue)
-        case .v2_1: return upgradeToVersion_2_1
-        case .v3_0: return upgradeToVersion_3_0_new // (issue)
-        case .v4_0: return upgradeToVersion_4_0
+        case .v0_0: return .success // this is here to satisfy the switch statement without putting in 'default'
+        case .v1_0: return upgradeToVersion_1_0()
+        case .v1_1: return upgradeToVersion_1_1()
+        case .v2_0: return upgradeToVersion_2_0_new() // (issue)
+        case .v2_1: return upgradeToVersion_2_1()
+        case .v3_0: return upgradeToVersion_3_0_new() // (issue)
+        case .v4_0: return upgradeToVersion_4_0()
         }
     }
 
@@ -111,7 +111,7 @@ class MyAppUpgrader: AppUpgradable {
     }
 }
 
-let myAppUpgrader = MyAppUpgrader()
+let myAppUpgrader = MyAppUpgrader(appUpgrader: AppUpgrader<MyAppVersion>(name: "com.company.myappversion"))
 
 do {
     try myAppUpgrader.upgradeApp()
@@ -131,3 +131,19 @@ do {
 }
 
 print("\nFinished Upgrade: new version \(myAppUpgrader.getCurrentVersion())")
+
+// Creating a Spry fake proof of concept
+class FakeAppUpgrader: AppUpgrader<MyAppVersion> {
+    init() {
+        super.init(name: "")
+    }
+    
+    override func upgrade(upgradeClosure: @escaping (MyAppVersion) -> UpgradeResult) throws {
+        // try throwingSpryify(upgradeClosure)
+    }
+    
+    override func getCurrentVersion() -> MyAppVersion {
+        return .v0_0
+        // return spryify()
+    }
+}

--- a/AppUpgradable.playground/Sources/AppUpgradable.swift
+++ b/AppUpgradable.playground/Sources/AppUpgradable.swift
@@ -35,9 +35,11 @@ public protocol AppUpgradable {
 
 open class AppUpgrader<T: RawRepresentable> where T.RawValue == Int {
     
+    private let userDefaults: UserDefaults
     private let name: String
     
-    public init(name: String) {
+    public init(userDefaults: UserDefaults = UserDefaults.standard, name: String) {
+        self.userDefaults = userDefaults
         self.name = name
     }
     
@@ -50,7 +52,7 @@ open class AppUpgrader<T: RawRepresentable> where T.RawValue == Int {
     }
     
     open func getCurrentVersion() -> T {
-        let savedVersion = UserDefaults.standard.integer(forKey: name)
+        let savedVersion = userDefaults.integer(forKey: name)
         return makeVersion(savedVersion)!
     }
     
@@ -110,8 +112,8 @@ open class AppUpgrader<T: RawRepresentable> where T.RawValue == Int {
     }
     
     private func setCurrentVersion(version: T) {
-        UserDefaults.standard.set(version.rawValue, forKey: name)
-        UserDefaults.standard.synchronize()
+        userDefaults.set(version.rawValue, forKey: name)
+        userDefaults.synchronize()
     }
     
     private func parseErrors(from upgradResults: [UpgradeResult]) -> (fatal: [Error], nonFatal: [Error]) {


### PR DESCRIPTION
This allows the `AppUpgradable` class to be mocked, regardless of the `RawRepresentable` type of the `Version` (which is now an `AppVersion`) type that is used. In most contexts, the `AppVersion` will only ever be an `Int`. These changes reflect this assumption.